### PR TITLE
[android] Changed android jar dependencies to AIR platform dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ ChangeLog
 2014-01-16 (version v1.4.6-jp-0)
  Initial release for Mobage SDK 1.4.6
 
+2014-03-38 (version v1.4.6-jp-1)
+ Changed android jar dependencies to AIR platform dependencies 
+
 
 ENVIRONMENT
 ==========================================================================

--- a/android/Makefile
+++ b/android/Makefile
@@ -30,7 +30,7 @@ MOBAGE_SDK_CLASS_FILE=$(REGION)/bin/classes/com/mobage/android/Mobage.class
 
 ifeq ($(REGION), jp)
 
-DEPENDENCIES=$(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/AppAdForce.jar $(REGION)/libs/FlashRuntimeExtensions.jar $(REGION)/libs/android-support-v4.jar $(MOBAGE_SDK_CLASS_FILE) \
+DEPENDENCIES=$(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/AppAdForce.jar $(REGION)/libs/FlashRuntimeExtensions.jar $(REGION)/libs/android-support-v4.jar \
 	$(REGION)/build.xml $(REGION)/local.properties $(REGION)/proguard-project.txt
 
 $(OUTPUT_JAR): $(DEPENDENCIES)
@@ -38,12 +38,12 @@ $(OUTPUT_JAR): $(DEPENDENCIES)
 	cd ./$(REGION); ant $(BUILD_TARGET)
 	cp $(REGION)/bin/classes.jar $@
 
-$(MOBAGE_SDK_CLASS_FILE):
-	mkdir -p $(REGION)/bin/classes
-	unzip -o $(MOBAGE_SDK_JAR_FILE) -d $(REGION)/bin/classes -x META-INF/*
-	unzip -o $(MOBAGE_SDK_JAR_FILE2) -d $(REGION)/bin/classes -x META-INF/*
-	unzip -o $(MOBAGE_SDK_JAR_FILE3) -d $(REGION)/bin/classes -x META-INF/*
-	touch $(MOBAGE_SDK_CLASS_FILE)
+# $(MOBAGE_SDK_CLASS_FILE):
+#	mkdir -p $(REGION)/bin/classes
+#	unzip -o $(MOBAGE_SDK_JAR_FILE) -d $(REGION)/bin/classes -x META-INF/*
+#	unzip -o $(MOBAGE_SDK_JAR_FILE2) -d $(REGION)/bin/classes -x META-INF/*
+#	unzip -o $(MOBAGE_SDK_JAR_FILE3) -d $(REGION)/bin/classes -x META-INF/*
+#	touch $(MOBAGE_SDK_CLASS_FILE)
 
 $(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/AppAdForce.jar $(REGION)/libs/android-support-v4.jar :
 	cp -pR $(MOBAGE_SDK_JAR_PATH)/ $(REGION)/libs/
@@ -54,7 +54,7 @@ $(REGION)/libs/FlashRuntimeExtensions.jar:
 # for KR
 else
 
-DEPENDENCIES=$(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/armeabi/libmobage.so $(REGION)/libs/FlashRuntimeExtensions.jar $(REGION)/libs/android-support-v4.jar $(REGION)/libs/armeabi-v7a/libmobage.so $(MOBAGE_SDK_CLASS_FILE) \
+DEPENDENCIES=$(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/armeabi/libmobage.so $(REGION)/libs/FlashRuntimeExtensions.jar $(REGION)/libs/android-support-v4.jar $(REGION)/libs/armeabi-v7a/libmobage.so \
 	$(REGION)/build.xml $(REGION)/local.properties $(REGION)/proguard-project.txt
 
 $(OUTPUT_JAR): $(DEPENDENCIES)
@@ -62,11 +62,11 @@ $(OUTPUT_JAR): $(DEPENDENCIES)
 	cd ./$(REGION); ant $(BUILD_TARGET)
 	cp $(REGION)/bin/classes.jar $@
 
-$(MOBAGE_SDK_CLASS_FILE):
-	mkdir -p $(REGION)/bin/classes
-	unzip -o $(MOBAGE_SDK_JAR_FILE) -d $(REGION)/bin/classes -x META-INF/*
-	unzip -o $(MOBAGE_SDK_JAR_FILE2) -d $(REGION)/bin/classes -x META-INF/*
-	touch $(MOBAGE_SDK_CLASS_FILE)
+# $(MOBAGE_SDK_CLASS_FILE):
+#	mkdir -p $(REGION)/bin/classes
+#	unzip -o $(MOBAGE_SDK_JAR_FILE) -d $(REGION)/bin/classes -x META-INF/*
+#	unzip -o $(MOBAGE_SDK_JAR_FILE2) -d $(REGION)/bin/classes -x META-INF/*
+#	touch $(MOBAGE_SDK_CLASS_FILE)
 
 $(REGION)/libs/MobageNativeSdk.jar $(REGION)/libs/armeabi/libmobage.so $(REGION)/libs/android-support-v4.jar $(REGION)/libs/armeabi-v7a/libmobage.so:
 	cp -pR $(MOBAGE_SDK_JAR_PATH)/ $(REGION)/libs/

--- a/as/Android-options.xml
+++ b/as/Android-options.xml
@@ -1,0 +1,7 @@
+<platform xmlns="http://ns.adobe.com/air/extension/4.0">
+    <packagedDependencies>
+        <packagedDependency>android-support-v4.jar</packagedDependency>
+        <packagedDependency>AppAdForce.jar</packagedDependency>
+        <packagedDependency>MobageNativeSdk.jar</packagedDependency>
+    </packagedDependencies>
+</platform>

--- a/as/Makefile
+++ b/as/Makefile
@@ -54,12 +54,12 @@ INPUT_ADL_SWF=$(ADL_DIR)/library.swf
 INPUT_MOBAGE_SDK=$(ANDROID_DIR)/libs $(ANDROID_DIR)/res $(ANDROID_DIR)/res_rn_v9 $(IOS_DIR)/MobageSDK $(IOS_SIMULATOR_DIR)/MobageSDK
 
 # path to Mobage Native SDK
-MOBAGE_ANDROID_SDK_FILES=$(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/libs $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/res $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/res_rn_v9
+MOBAGE_ANDROID_SDK_FILES=$(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/libs/android-support-v4.jar $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/libs/MobageNativeSdk.jar $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/libs/AppAdForce.jar $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/res $(MOBAGE_SDK_PATH)/android/MobageNativeAndroid/res_rn_v9
 MOBAGE_IOS_SDK_PATH=$(MOBAGE_SDK_PATH)/ios/MobageSDK
 
 $(OUTPUT_ANE): $(OUTPUT_SWC) $(INPUT_ANDROID_SWF) $(INPUT_IOS_SWF) $(INPUT_IOS_SIMULATOR_SWF) $(INPUT_ADL_SWF) $(INPUT_MOBAGE_SDK)
 	$(FLASH_SDK_PATH)/bin/adt -package -target ane $@ extension.xml -swc bin/ANE4MobageSDK.swc \
-		-platform Android-ARM -C $(ANDROID_DIR) . \
+		-platform Android-ARM -C $(ANDROID_DIR) -platformoptions Android-options.xml . \
 		-platform iPhone-ARM -C $(IOS_DIR) -platformoptions iOS-options.xml . \
 		-platform iPhone-x86 -C $(IOS_SIMULATOR_DIR) -platformoptions iOS-options.xml . \
 		-platform default -C $(ADL_DIR) .


### PR DESCRIPTION
Developer can now pick which jar to include in ANE by editing "Android-options.xml".
