### PR TITLE
iAd.frameworkを追加

### DIFF
--- a/as/iOS-options.xml
+++ b/as/iOS-options.xml
@@ -4,6 +4,7 @@
          <option>-ios_version_min 5.1.1</option>
          <option>-framework StoreKit</option>
          <option>-weak_framework AdSupport</option>
+         <option>-framework iAd</option>
     </linkerOptions>
 </platform>
 


### PR DESCRIPTION
@manavy 

Mobage Native SDK 1.4.7.5で `iAd.framework` が必須になったようなので `iOS-options.xml` に追加。
